### PR TITLE
Fixes #13: Add validation handler to 3 post requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,8 @@ Flask Application
 '''
 from flask import Flask, jsonify, request
 from models import Experience, Education, Skill
+from typing import List, Dict, Any
+from dataclasses import asdict
 
 app = Flask(__name__)
 
@@ -30,6 +32,14 @@ data = {
     ]
 }
 
+def validate_fields(required_fields: List[str], request_data: Dict[str, Any]) -> tuple:
+    '''
+    Validate that all the required fields are present in the request data
+    '''
+    missing_fields = [field for field in required_fields if field not in request_data]
+    if missing_fields: 
+        return False, f"Missing required fields: {', '.join(missing_fields)}"
+    return True, ""
 
 @app.route('/test')
 def hello_world():
@@ -37,7 +47,6 @@ def hello_world():
     Returns a JSON test message
     '''
     return jsonify({"message": "Hello, World!"})
-
 
 @app.route('/resume/experience', methods=['GET', 'POST'])
 def experience():
@@ -48,9 +57,21 @@ def experience():
         return jsonify()
 
     if request.method == 'POST':
-        return jsonify({})
+        request_data = request.get_json()
+        required_fields = ["title", "company", "start_date", "end_date", "description", "logo"]
+        is_valid, error_mssg = validate_fields(required_fields, request_data)
 
-    return jsonify({})
+        if not is_valid: 
+            return jsonify({"error": error_mssg}), 400
+        
+        try: 
+            new_experience = Experience(**request_data)
+            data["experience"].append(new_experience)
+            return jsonify(asdict(new_experience)), 201
+        except TypeError as e: 
+            return jsonify({"error": str(e)}), 400
+
+    return jsonify({}), 405
 
 @app.route('/resume/education', methods=['GET', 'POST'])
 def education():
@@ -61,9 +82,20 @@ def education():
         return jsonify({})
 
     if request.method == 'POST':
-        return jsonify({})
+        request_data = request.get_json()
+        required_fields = ["course", "school", "start_date", "end_date", "grade", "logo"]
+        is_valid, error_mssg = validate_fields(required_fields, request_data)
+        
+        if not is_valid:
+            return jsonify({"error": error_mssg}), 400
+        try: 
+            new_education = Education(**request_data)
+            data["education"].append(new_education)
+            return jsonify(asdict(new_education)), 201
+        except TypeError as e:
+            return jsonify({"error": str(e)}), 400
 
-    return jsonify({})
+    return jsonify({}), 405
 
 
 @app.route('/resume/skill', methods=['GET', 'POST'])
@@ -75,6 +107,17 @@ def skill():
         return jsonify({})
 
     if request.method == 'POST':
-        return jsonify({})
+        request_data = request.get_json()
+        required_fields = ["name", "proficiency", "logo"]
+        is_valid, error_mssg = validate_fields(required_fields, request_data)
+        
+        if not is_valid:
+            return jsonify({"error": error_mssg}), 400
+        try: 
+            new_skill = Skill(**request_data)
+            data["skill"].append(new_skill)
+            return jsonify(asdict(new_skill)), 201
+        except TypeError as e:
+            return jsonify({"error": str(e)}), 400
 
-    return jsonify({})
+    return jsonify({}), 405

--- a/app.py
+++ b/app.py
@@ -1,10 +1,10 @@
 '''
 Flask Application
 '''
+from dataclasses import asdict
+from typing import List, Dict, Any
 from flask import Flask, jsonify, request
 from models import Experience, Education, Skill
-from typing import List, Dict, Any
-from dataclasses import asdict
 
 app = Flask(__name__)
 

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -34,6 +34,9 @@ def test_experience():
     assert response.json[item_id] == example_experience
 
 def test_experience_post_success():
+    """
+    Test the successful creation of a new experience entry.
+    """
     new_experience = {
         "title": "Software Engineer",
         "company": "Tech Corp",
@@ -42,13 +45,16 @@ def test_experience_post_success():
         "description": "Full stack development",
         "logo": "tech-corp-logo.png"
     }
-    response = app.test_client().post('/resume/experience', 
+    response = app.test_client().post('/resume/experience',
                            json=new_experience)
     assert response.status_code == 201
     for key, value in response.json.items():
         assert new_experience[key] == value
 
 def test_experience_post_missing_fields():
+    """
+    Test the unsuccessful creation of a new experience entry because of missing fields.
+    """
     incomplete_experience = {
         "title": "Data Engineer",
         "company": "Google"
@@ -79,6 +85,9 @@ def test_education():
     assert response.json[item_id] == example_education
 
 def test_post_education_success():
+    """
+    Test the successful creation of a new education entry.
+    """
     new_education = {
         "course": "Master's in Computer Science",
         "school": "Tech University",
@@ -95,6 +104,9 @@ def test_post_education_success():
         assert new_education[key] == value
 
 def test_post_education_missing_fields():
+    """
+    Test the unsuccessful creation of a new education entry because of missing fields.
+    """
     incomplete_education = {
         "course": "PhD in Computer Science",
         "school": "Cornell University"
@@ -124,6 +136,9 @@ def test_skill():
     assert response.json[item_id] == example_skill
 
 def test_post_skill_success():
+    """
+    Test the successful creation of a new post entry.
+    """
     new_skill = {
         "name": "JavaScript",
         "proficiency": "3-4 Years",
@@ -137,6 +152,9 @@ def test_post_skill_success():
         assert new_skill[key] == value
 
 def test_post_skill_missing_fields():
+    """
+    Test the unsuccessful creation of a new skill entry because of missing fields.
+    """
     incomplete_skill = {
         "name": "JavaScript"
     }

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -33,6 +33,30 @@ def test_experience():
     response = app.test_client().get('/resume/experience')
     assert response.json[item_id] == example_experience
 
+def test_experience_post_success():
+    new_experience = {
+        "title": "Software Engineer",
+        "company": "Tech Corp",
+        "start_date": "January 2023",
+        "end_date": "Present",
+        "description": "Full stack development",
+        "logo": "tech-corp-logo.png"
+    }
+    response = app.test_client().post('/resume/experience', 
+                           json=new_experience)
+    assert response.status_code == 201
+    for key, value in response.json.items():
+        assert new_experience[key] == value
+
+def test_experience_post_missing_fields():
+    incomplete_experience = {
+        "title": "Data Engineer",
+        "company": "Google"
+    }
+    response = app.test_client().post('/resume/experience', 
+                           json=incomplete_experience)
+    assert response.status_code == 400
+    assert 'error' in response.json
 
 def test_education():
     '''
@@ -54,6 +78,32 @@ def test_education():
     response = app.test_client().get('/resume/education')
     assert response.json[item_id] == example_education
 
+def test_post_education_success():
+    new_education = {
+        "course": "Master's in Computer Science",
+        "school": "Tech University",
+        "start_date": "September 2022",
+        "end_date": "June 2024",
+        "grade": "3.8 GPA",
+        "logo": "tech-uni-logo.png"
+    }
+    response = app.test_client().post('/resume/education', 
+                            json=new_education,
+                            content_type='application/json')
+    assert response.status_code == 201
+    for key, value in response.json.items():
+        assert new_education[key] == value
+
+def test_post_education_missing_fields():
+    incomplete_education = {
+        "course": "PhD in Computer Science",
+        "school": "Cornell University"
+    }
+    response = app.test_client().post('/resume/education', 
+                            json=incomplete_education,
+                            content_type='application/json')
+    assert response.status_code == 400
+    assert 'error' in response.json
 
 def test_skill():
     '''
@@ -72,3 +122,26 @@ def test_skill():
 
     response = app.test_client().get('/resume/skill')
     assert response.json[item_id] == example_skill
+
+def test_post_skill_success():
+    new_skill = {
+        "name": "JavaScript",
+        "proficiency": "3-4 Years",
+        "logo": "js-logo.png"
+    }
+    response = app.test_client().post('/resume/skill', 
+                            json=new_skill,
+                            content_type='application/json')
+    assert response.status_code == 201
+    for key, value in response.json.items():
+        assert new_skill[key] == value
+
+def test_post_skill_missing_fields():
+    incomplete_skill = {
+        "name": "JavaScript"
+    }
+    response = app.test_client().post('/resume/skill', 
+                            json=incomplete_skill,
+                            content_type='application/json')
+    assert response.status_code == 400
+    assert 'error' in response.json


### PR DESCRIPTION
Resolves #13 

* Create a function validate_fields: 
  * Inputs: required_fields, request_data
  * Output: boolean, error_message

* In each of the post requests: 
  * Check whether it has all the required fields using the function above 
  * If it is, then add that new request into data object 
  * Return the json object back to frontend accordingly

* Add 6 test cases for 3 post requests:
  * One test case for successful creation of a new entry 
  * One test case for unsuccessful creation because of missing fields 