### PR TITLE
feat: reorder section items on the backend

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,7 +90,7 @@ def experience():
 
     if request.method == 'POST':
         return jsonify({})
-    
+
     if request.method == 'PUT':
         body = request.get_json()
         new_experience_order = []
@@ -102,7 +102,9 @@ def experience():
             description = exp['description']
             logo = exp['logo']
 
-            new_experience_order.append(Experience(title, company, start_date, end_date, description, logo))
+            new_experience_order.append(
+                Experience(title, company, start_date, end_date, description, logo)
+                )
         data['experience'] = new_experience_order
 
         return_data = [item.__dict__ for item in data['experience']]
@@ -120,7 +122,7 @@ def education():
 
     if request.method == 'POST':
         return jsonify({})
-    
+
     if request.method == 'PUT':
         body = request.get_json()
         new_education_order = []
@@ -149,7 +151,7 @@ def skill():
 
     if request.method == 'POST':
         return jsonify({})
-    
+
     if request.method == 'PUT':
         body = request.get_json()
         new_skill_order = []

--- a/app.py
+++ b/app.py
@@ -80,42 +80,87 @@ def user():
     # add a default return statement for unsupported request methods
     return jsonify({"error": "Unsupported request method !"}), 405
 
-@app.route('/resume/experience', methods=['GET', 'POST'])
+@app.route('/resume/experience', methods=['GET', 'POST', 'PUT'])
 def experience():
     '''
     Handle experience requests
     '''
     if request.method == 'GET':
-        return jsonify()
+        return jsonify([item.__dict__ for item in data['experience']]), 200
 
     if request.method == 'POST':
         return jsonify({})
+    
+    if request.method == 'PUT':
+        body = request.get_json()
+        new_experience_order = []
+        for exp in body['data']:
+            title = exp['title']
+            company = exp['company']
+            start_date = exp['start_date']
+            end_date = exp['end_date']
+            description = exp['description']
+            logo = exp['logo']
 
-    return jsonify({})
+            new_experience_order.append(Experience(title, company, start_date, end_date, description, logo))
+        data['experience'] = new_experience_order
 
-@app.route('/resume/education', methods=['GET', 'POST'])
+        return_data = [item.__dict__ for item in data['experience']]
+        return jsonify(return_data), 200
+
+    return jsonify({"error": "Unsupported request method !"}), 405
+
+@app.route('/resume/education', methods=['GET', 'POST', 'PUT'])
 def education():
     '''
     Handles education requests
     '''
     if request.method == 'GET':
-        return jsonify({})
+        return jsonify([item.__dict__ for item in data['education']]), 200
 
     if request.method == 'POST':
         return jsonify({})
+    
+    if request.method == 'PUT':
+        body = request.get_json()
+        new_education_order = []
+        for edu in body['data']:
+            course = edu['course']
+            school = edu['school']
+            start_date = edu['start_date']
+            end_date = edu['end_date']
+            grade = edu['grade']
+            logo = edu['logo']
+            new_education_order.append(Education(course, school, start_date, end_date, grade, logo))
+        data['education'] = new_education_order
 
+        return_data = [item.__dict__ for item in data['education']]
+        return jsonify(return_data), 200
     return jsonify({})
 
 
-@app.route('/resume/skill', methods=['GET', 'POST'])
+@app.route('/resume/skill', methods=['GET', 'POST', 'PUT'])
 def skill():
     '''
     Handles Skill requests
     '''
     if request.method == 'GET':
-        return jsonify({})
+        return jsonify([item.__dict__ for item in data['skill']]), 200
 
     if request.method == 'POST':
         return jsonify({})
+    
+    if request.method == 'PUT':
+        body = request.get_json()
+        new_skill_order = []
+        for skill in body['data']:
+            name = skill['name']
+            proficiency = skill['proficiency']
+            logo = skill['logo']
+            new_skill_order.append(Skill(name, proficiency, logo))
+        data['skill'] = new_skill_order
+
+        return_data = [item.__dict__ for item in data['skill']]
+        return jsonify(return_data), 200
 
     return jsonify({})

--- a/app.py
+++ b/app.py
@@ -149,7 +149,7 @@ def education():
     if request.method == 'GET':
         return jsonify(
             {"education": [edu.__dict__ for edu in data["education"]]})
-    
+
     if request.method == "POST":
         new_education = request.json
         new_edu = new_education["data"][0]
@@ -195,8 +195,8 @@ def skill():
         new_skill = request.json
         skill_data = new_skill["data"][0]
         skill_instance = Skill(
-            skill_data["name"], 
-            skill_data["proficiency"], 
+            skill_data["name"],
+            skill_data["proficiency"],
             skill_data["logo"]
         )
         data["skill"].append(skill_instance)
@@ -205,10 +205,10 @@ def skill():
     if request.method == 'PUT':
         body = request.get_json()
         new_skill_order = []
-        for skill in body['data']:
-            name = skill['name']
-            proficiency = skill['proficiency']
-            logo = skill['logo']
+        for _skill in body['data']:
+            name = _skill['name']
+            proficiency = _skill['proficiency']
+            logo = _skill['logo']
             new_skill_order.append(Skill(name, proficiency, logo))
         data['skill'] = new_skill_order
 

--- a/app.py
+++ b/app.py
@@ -103,17 +103,19 @@ def experience():
     Handle experience requests
     """
     if request.method == 'GET':
-        return jsonify()
+        return jsonify(
+            {"experience": [exp.__dict__ for exp in data["experience"]]})
 
     if request.method == "POST":
         new_experience = request.json
+        new_exp = new_experience["data"][0]
         experience_instance = Experience(
-            new_experience["title"],
-            new_experience["company"],
-            new_experience["start_date"],
-            new_experience["end_date"],
-            new_experience["description"],
-            new_experience["logo"],
+            new_exp["title"],
+            new_exp["company"],
+            new_exp["start_date"],
+            new_exp["end_date"],
+            new_exp["description"],
+            new_exp["logo"],
         )
         data["experience"].append(experience_instance)
         return jsonify({"id": len(data["experience"]) - 1})
@@ -139,23 +141,25 @@ def experience():
 
     return jsonify({"error": "Unsupported request method !"}), 405
 
-@app.route('/resume/education', methods=['GET', 'POST'])
+@app.route('/resume/education', methods=['GET', 'POST', 'PUT'])
 def education():
     """
     Handles education requests
     """
     if request.method == 'GET':
-        return jsonify({})
-
+        return jsonify(
+            {"education": [edu.__dict__ for edu in data["education"]]})
+    
     if request.method == "POST":
         new_education = request.json
+        new_edu = new_education["data"][0]
         education_instance = Education(
-            new_education["course"],
-            new_education["school"],
-            new_education["start_date"],
-            new_education["end_date"],
-            new_education["grade"],
-            new_education["logo"],
+            new_edu["course"],
+            new_edu["school"],
+            new_edu["start_date"],
+            new_edu["end_date"],
+            new_edu["grade"],
+            new_edu["logo"],
         )
         data["education"].append(education_instance)
         return jsonify({"id": len(data["education"]) - 1})
@@ -189,8 +193,11 @@ def skill():
 
     if request.method == "POST":
         new_skill = request.json
+        skill_data = new_skill["data"][0]
         skill_instance = Skill(
-            new_skill["name"], new_skill["proficiency"], new_skill["logo"]
+            skill_data["name"], 
+            skill_data["proficiency"], 
+            skill_data["logo"]
         )
         data["skill"].append(skill_instance)
         return jsonify({"id": len(data["skill"]) - 1})

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -59,18 +59,42 @@ def test_experience():
     Check that it returns the new experience in that list
     '''
     example_experience = {
-        "title": "Software Developer",
-        "company": "A Cooler Company",
-        "start_date": "October 2022",
-        "end_date": "Present",
-        "description": "Writing JavaScript Code",
-        "logo": "example-logo.png"
+        "data": [
+            {
+                "title": "Software Developer",
+                "company": "A Cooler Company",
+                "start_date": "October 2022",
+                "end_date": "Present",
+                "description": "Writing JavaScript Code",
+                "logo": "example-logo.png"
+            }
+        ]
     }
 
     item_id = app.test_client().post('/resume/experience',
                                      json=example_experience).json['id']
     response = app.test_client().get('/resume/experience')
     assert response.json[item_id] == example_experience
+
+    # test PUT request
+    response = app.test_client().put('/resume/experience', json={"data": [
+            {
+                "title": "Software Developer",
+                "company": "The Coolest Company",
+                "start_date": "October 2024",
+                "end_date": "Present",
+                "description": "Writing Python Code",
+                "logo": "example-logo.png"
+            }
+        ]})
+    assert response.status_code == 200
+    response_data = response.json[0]
+    assert response_data['title'] == 'Software Developer'
+    assert response_data['company'] == 'The Coolest Company'
+    assert response_data['start_date'] == 'October 2024'
+    assert response_data['end_date'] == 'Present'
+    assert response_data['description'] == 'Writing Python Code'
+    assert response_data['logo'] == 'example-logo.png'
 
 
 def test_education():
@@ -79,19 +103,41 @@ def test_education():
     
     Check that it returns the new education in that list
     '''
-    example_education = {
+    example_education = {"data": [{
         "course": "Engineering",
         "school": "NYU",
         "start_date": "October 2022",
         "end_date": "August 2024",
         "grade": "86%",
         "logo": "example-logo.png"
-    }
+    }]}
+
     item_id = app.test_client().post('/resume/education',
                                      json=example_education).json['id']
 
     response = app.test_client().get('/resume/education')
     assert response.json[item_id] == example_education
+
+    response = app.test_client().put('/resume/education', json={
+        "data": [
+            {
+                "course": "Updated Course",
+                "school": "Updated University",
+                "start_date": "September 2020",
+                "end_date": "June 2023",
+                "grade": "90%",
+                "logo": "new-education-logo.png"
+            }
+        ]
+    })
+    assert response.status_code == 200
+    response_data = response.json[0]
+    assert response_data['course'] == 'Updated Course'
+    assert response_data['school'] == 'Updated University'
+    assert response_data['start_date'] == 'September 2020'
+    assert response_data['end_date'] == 'June 2023'
+    assert response_data['grade'] == '90%'
+    assert response_data['logo'] == 'new-education-logo.png'
 
 
 def test_skill():
@@ -111,3 +157,19 @@ def test_skill():
 
     response = app.test_client().get('/resume/skill')
     assert response.json[item_id] == example_skill
+
+    response = app.test_client().put('/resume/skill', json={
+        "data": [
+            {
+                "name": "Python",
+                "proficiency": "4-6 years",
+                "logo": "new-logo.png"
+            }
+        ]
+    })
+    assert response.status_code == 200
+    response_data = response.json[0]
+    assert response_data['name'] == 'Python'
+    assert response_data['proficiency'] == '4-6 years'
+    assert response_data['logo'] == 'new-logo.png'
+

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -77,7 +77,8 @@ def test_experience():
     item_id = app.test_client().post('/resume/experience',
                                      json=example_experience).json['id']
     response = app.test_client().get('/resume/experience')
-    assert response.json["experience"][item_id] == example_experience
+    print(response.json)
+    assert response.json["experience"][item_id] == example_experience['data'][0]
 
     # test PUT request
     response = app.test_client().put('/resume/experience', json={"data": [
@@ -119,7 +120,7 @@ def test_education():
                                      json=example_education).json['id']
 
     response = app.test_client().get('/resume/education')
-    assert response.json["education"][item_id] == example_education
+    assert response.json["education"][item_id] == example_education['data'][0]
 
     response = app.test_client().put('/resume/education', json={
         "data": [
@@ -149,17 +150,18 @@ def test_skill():
     
     Check that it returns the new skill in that list
     '''
-    example_skill = {
+    example_skill = { "data":[{
         "name": "JavaScript",
         "proficiency": "2-4 years",
         "logo": "example-logo.png"
+    }]
     }
 
     item_id = app.test_client().post('/resume/skill',
                                      json=example_skill).json['id']
 
     response = app.test_client().get('/resume/skill')
-    assert response.json["skills"][item_id] == example_skill
+    assert response.json["skills"][item_id] == example_skill["data"][0]
 
     response = app.test_client().put('/resume/skill', json={
         "data": [


### PR DESCRIPTION
This PR resolves issue #12 

I implemented /PUT endpoints to update the order of the items in the experience, education and skills sections.

- [x] A user can change the order that their Experience, Education and Skill sections are displayed.

I have collaborated with @6ri4n, the fellow working on the [frontend implementation](https://github.com/MLH-Fellowship/orientation-project-js-24.FAL.B/pull/18) of this issue to agree on a standard data format.